### PR TITLE
Use string for out version value.

### DIFF
--- a/out
+++ b/out
@@ -85,4 +85,4 @@ else
   echo "body: ${body}"
 fi
 
-jq -n '{version:{ref:0}}' >&3
+jq -n "{version:{timestamp:\"$(date +%s)\"}}"


### PR DESCRIPTION
- concourse expects map[string]string
- use timestamp so the values are unique and monotonically increasing.