### PR TITLE
Add missing file descriptor.

### DIFF
--- a/out
+++ b/out
@@ -85,4 +85,4 @@ else
   echo "body: ${body}"
 fi
 
-jq -n "{version:{timestamp:\"$(date +%s)\"}}"
+jq -n "{version:{timestamp:\"$(date +%s)\"}}" >&3


### PR DESCRIPTION
otherwise json output doesn't get sent back to std out and concourse errors