### PR TITLE
Do not send notification if text file is empty

### DIFF
--- a/out
+++ b/out
@@ -33,6 +33,12 @@ else
   text="$(jq '(.params.text // "")' < "${payload}")"
 fi
 
+if [[ "${text}" == "" ]]; then
+  echo "the text payload is empty"
+  jq -n "{version:{timestamp:\"$(date +%s)\"}}" >&3
+  exit 0
+fi
+
 username="$(jq '(.params.username // null)' < "${payload}")"
 icon_url="$(jq '(.params.icon_url // null)' < "${payload}")"
 icon_emoji="$(jq '(.params.icon_emoji // null)' < "${payload}")"


### PR DESCRIPTION
The existing behavior is such that the `put` will fail if a provided text_file is empty. We thought it would be useful not to send a notification if the text_file is empty -- this allows 'conditional' notifications. Does this seem like reasonable behavior?

Nick && David (@dsabeti)