### PR TITLE
Fixes printf for text

### DIFF
--- a/out
+++ b/out
@@ -45,7 +45,7 @@ icon_emoji="$(jq '(.params.icon_emoji // null)' < "${payload}")"
 channel="$(jq '(.params.channel // null)' < "${payload}")"
 
 if [ "${text}" != "" ]; then
-  text="$(eval "printf ${text}" | jq -R -s .)"
+  text="$(eval "printf '${text}'" | jq -R -s .)"
 fi
 
 if [ "${username}" != "null" ]; then


### PR DESCRIPTION
We are wrapping the multiline text with a quote so that the entire multiline text is printed instead of just the first line. 

For example, wrapping a multiline text without quotes throws the following error:
```
eval "printf this is line 1
> this is line 2
> this is line 3"
thisbash: this: command not found
bash: this: command not found
```

Wrapping the multiline text with quote will print successfully:
```
eval "printf 'this is line 1
this is line 2
this is line 3'"
this is line 1
this is line 2
this is line 3
```

@drnic @longnguyen11288 : when we get this merged, can we create a new bosh release with the updated resource as well please?

**update: ** Noticed that this is actually failing for strings with spaces as well.
