### PR TITLE
Adding set +x to prevent slack hook endpoint from being exposed

### DIFF
--- a/out
+++ b/out
@@ -6,7 +6,7 @@ cd "${1}"
 
 exec 3>&1
 exec 1>&2
-
+set +x
 # for jq
 PATH=/usr/local/bin:$PATH
 


### PR DESCRIPTION
Not sure if this is the right solution, but we shouldn't be exposing webhook, which allows any users to post on a channel. 

Thoughts?

Signed-off-by: Forest Eckhardt <forest.eckhardt@gmail.com>