### PR TITLE
Allow printf to be more flexible with slack message content.

### DIFF
--- a/out
+++ b/out
@@ -64,8 +64,7 @@ fi
 if [[ "$always_notify" == "true" || -n "$TEXT_FILE_CONTENT" || -z "$text_file" ]]
 then
   TEXT_FILE_CONTENT="${TEXT_FILE_CONTENT:-_(no notification provided)_}"
-
-  text="$(eval printf ${text} )"
+  text="$(eval printf "%b" ${text} )"
   [[ -z "${text}" ]] && text="_(missing notification text)_"
   text="$(echo "${text}" | jq -R -s .)"
 


### PR DESCRIPTION
- I have a situation where I have a dash '-' in a url that I would like
  to send via a slack message. I was getting errors saying I cannot do
  this.
- The %b format flag does this "Print the associated argument while
  interpreting backslash escapes in there". This allows you to keep
  using \n characters in your messages, but also not try to interpret
  any dashes as additional command line arguments!!

- I tried a number of other approaches to get this working. The internet will tell you to do printf -- "your-dash-string-here". But that does not work with this version of printf.

- I have built the docker image and uploaded it for temporary use [here](https://hub.docker.com/r/jackman3005/slack-notification-resource/)
- All tests pass. Sorry I did not add one, crunched on time. If it's a big deal I can get to it later.

Cheers! 