### PR TITLE
Interpolate the 'text' field in attachments.

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,5 @@
+# Bug Fixes
+
+- The `text` field of attachments now interpolates environment
+  variables from the container environment (i.e. BUILD_* et al).
+  Fixes #25

--- a/out
+++ b/out
@@ -68,6 +68,24 @@ then
   if [[ "${attachments}" == "null" ]]
   then
     TEXT_FILE_CONTENT="${TEXT_FILE_CONTENT:-_(no notification provided)_}"
+  else
+    # we have attachments; better interpolate the `text' field...
+    workfile=$(mktemp /tmp/attach.XXXXXX)
+    outfile=$(mktemp /tmp/attach.XXXXXX)
+    cat >$workfile <<<$attachments
+    for x in $(seq 1 $(jq -r 'length' < $workfile)); do
+      x=$(( x - 1 ))
+      if [[ $x != 0 ]]; then
+        echo -n "," >> $outfile
+      fi
+      attachment_text="$(jq -r ".[$x].text // "'""' < $workfile)"
+      interpolated='{}'
+      if [[ -n "$attachment_text" ]]; then
+        interpolated="$(echo $(eval printf "%b" \""$attachment_text"\" | jq -R '{"text":.}'))"
+      fi
+      jq -s '.[0] * .[1]' <(jq -r ".[$x]" <$workfile) <(echo "$interpolated") >> $outfile
+    done
+    attachments=$((echo '['; cat $outfile; echo ']') | jq -r .)
   fi
 
   text="$(eval printf "%b" ${text} )"

--- a/test/all.sh
+++ b/test/all.sh
@@ -145,13 +145,13 @@ test metadata_with_payload | jq -e "
 test attachments_no_text | jq -e "
   .body.text == null and
   .body.attachments[0].color == \"danger\" and
-  .body.attachments[0].text == \"Build failed!\" and
+  .body.attachments[0].text == \"Build my-build failed!\" and
   ( .body.attachments | length == 1 )"
 
 test attachments_with_text | jq -e "
   .body.text == \"Inline static text\n\" and
   .body.attachments[0].color == \"danger\" and
-  .body.attachments[0].text == \"Build failed!\" and
+  .body.attachments[0].text == \"Build my-build failed!\" and
   ( .body.attachments | length == 1 )"
 
 test multiple_channels | jq -e "

--- a/test/attachments_no_text.out
+++ b/test/attachments_no_text.out
@@ -6,7 +6,7 @@
     "attachments": [
       {
         "color": "danger",
-        "text": "Build failed!"
+        "text": "Build $BUILD_NAME failed!"
       }
     ]
   },

--- a/test/attachments_with_text.out
+++ b/test/attachments_with_text.out
@@ -7,7 +7,7 @@
     "attachments": [
       {
         "color": "danger",
-        "text": "Build failed!"
+        "text": "Build $BUILD_NAME failed!"
       }
     ]
   },


### PR DESCRIPTION
Fixes #25.

The gist of this change is to iterate over the attachments, pulling out
the `text' field and eval/printfing it, and then merging them back
together using jq's `*' operator.  This may not be the right way to do
this.  This may not be the best way to do this, but it does seem to
work, and that's got to count for something.

@dennisjbell / @geofffranks your jq-fu is most appreciated in a review of this PR...