### PR TITLE
Add HTTP(S) proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Source Configuration
 To setup an [Incoming Webhook](https://api.slack.com/incoming-webhooks) go to https://my.slack.com/services/new/incoming-webhook/.
 
 -	`url`: *Required.* The webhook URL as provided by Slack. Usually in the form: `https://hooks.slack.com/services/XXXX`
--   `insecure`: *Optional.* Connect to Concourse insecurely - i.e. skip SSL validation. Defaults to false if not provided.
+-   `insecure`: *Optional.* Connect to Slack insecurely - i.e. skip SSL validation. Defaults to false if not provided.
+- `proxy`: *Optional.* Connect to Slack using an HTTP(S) proxy. In the form: `http://my.proxy:3128`
+- `proxy_https_tunnel`: *Optional.* Set to `true` to use an HTTP proxy as an HTTPS tunnel.
 -   `ca_certs`: *Optional.* An array of objects with the following format:
 
   ```yaml

--- a/out
+++ b/out
@@ -36,6 +36,9 @@ silent="$(jq -r '.params.silent // "false"' < "${payload}")"
 always_notify="$(jq -r '.params.always_notify // "false"' < "${payload}")"
 redact_hook="$(jq -r '.params.redact_hook_url // "true"' < "${payload}")"
 
+proxy="$(jq -r '.source.proxy // "null"' < "${payload}")"
+proxy_https_tunnel="$(jq -r '.source.proxy_https_tunnel // "false"' < "${payload}")"
+
 
 cert_count="$(echo $raw_ca_certs | jq -r '. | length')"
 if [[ ${cert_count} -gt 0 ]]
@@ -57,7 +60,7 @@ ATTACHMENTS_FILE_CONTENT=""
 if [[ "${attachments}" == "null" && -n $ATTACHMENTS_FILE_CONTENT ]]; then
   attachments=$ATTACHMENTS_FILE_CONTENT
 fi
-  
+
 attachments=$(echo "$attachments" | envsubst)
 
 [[ -n "${channel_file}" && -f "${channel_file}" ]] && channels="${channels} $(cat "${channel_file}")"
@@ -73,6 +76,16 @@ body=""
 if [[ "$allow_insecure" == "true" ]]
 then
     CURL_OPTION="${CURL_OPTION} -k"
+fi
+
+if [[ "$proxy" != "null" ]]
+then
+    CURL_OPTION="${CURL_OPTION} --proxy ${proxy}"
+fi
+
+if [[ "$proxy_https_tunnel" == "true" ]]
+then
+    CURL_OPTION="${CURL_OPTION} --proxytunnel"
 fi
 
 if [[ "$always_notify" == "true" || -n "$TEXT_FILE_CONTENT" || -z "$text_file" ]]


### PR DESCRIPTION
Also fixed what appears to be a typo in the docs: "Connect to Concourse" → "Connect to Slack".