### PR TITLE
Added how to mention users to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ If you use `text` without using the `$TEXT_FILE_CONTENT` in it, the content
 will not be added to your message.
 
 The text and text_file content can contain multiple lines, emojis like :simple_smile:,
-and links in form `<http://example.com>` or `<http://example.com|Click here!>`.
+and links in form `<http://example.com>` or `<http://example.com|Click here!>`. 
+To mention a user, you will have to use the `<@U123ABC>` format. Note that the old `<@username>`
+format is no longer supported by Slack (See [changelog](https://api.slack.com/changelog/2017-09-the-one-about-usernames)).
+You can read more on how to mention users/channels in the [Slack documentation on message formatting](https://api.slack.com/docs/message-formatting#linking_to_channels_and_users).
 
 If you omit the `attachments` parameter, the contents of the file specified in the
 `attachments_file` parameter will be used verbatim.  If the `attachments` parameter

--- a/README.md
+++ b/README.md
@@ -83,9 +83,15 @@ will not be added to your message.
 
 The text and text_file content can contain multiple lines, emojis like :simple_smile:,
 and links in form `<http://example.com>` or `<http://example.com|Click here!>`. 
-To mention a user, you will have to use the `<@U123ABC>` format. Note that the old `<@username>`
-format is no longer supported by Slack (See [changelog](https://api.slack.com/changelog/2017-09-the-one-about-usernames)).
-You can read more on how to mention users/channels in the [Slack documentation on message formatting](https://api.slack.com/docs/message-formatting#linking_to_channels_and_users).
+To mention a user, you will have to use the `<@U123ABC>` format, where `U123ABC` 
+is the user ID. You can get a user's user ID by browsing their profile 
+and using the **⌵** control to display and quickly copy and paste a specific user's ID. 
+For more ways, see the [Slack documentation on username/user ID mapping](https://api.slack.com/changelog/2017-09-the-one-about-usernames#mapping). 
+You can read more on how to mention users/channels in the [Slack documentation on linking to channels and users](https://api.slack.com/docs/message-formatting#linking_to_channels_and_users).
+
+
+Note that the old `<@username>` format willl soon no longer be supported by Slack
+(See [changelog](https://api.slack.com/changelog/2017-09-the-one-about-usernames)).
 
 If you omit the `attachments` parameter, the contents of the file specified in the
 `attachments_file` parameter will be used verbatim.  If the `attachments` parameter


### PR DESCRIPTION
Added instructions for how to mention users in the text param to the `README.md`, along with a warning that the old format is no longer supported. Provided links to the official changelogs and the documentation where users can read more regarding this change and how to format their messages in general.