### PR TITLE
added linked_name option for the post body

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Optional:
 -	`icon_url`: *Optional.* Override icon by providing URL to the image.
 -	`icon_emoji`: *Optional.* Override icon by providing emoji code (e.g. `:ghost:`).
 - `silent`: *Optional.* Do not print curl output (avoids leaking slack webhook URL)
+- `link_names`: *Optional.* true or false (defaults to false). Will let you ping group by having @<group-name> in text if set to true.
 - `always_notify`: *Optional.* Attempt to notify even if there are errors or missing text. (Expects true or false, defaults to false)
 
 Explore formatting with Slack's [Message Builder](https://api.slack.com/docs/formatting/builder).

--- a/out
+++ b/out
@@ -23,6 +23,7 @@ text="$(jq -r '(.params.text // "${TEXT_FILE_CONTENT}")' < "${payload}")"
 username="$(jq '(.params.username // null)' < "${payload}")"
 icon_url="$(jq '(.params.icon_url // null)' < "${payload}")"
 icon_emoji="$(jq '(.params.icon_emoji // null)' < "${payload}")"
+link_names="$(jq -r '(.params.link_names // false)' < "${payload}")"
 
 channels="$(jq -r '(.params.channel // null)' < "${payload}")"
 channel_file="$(jq -r '(.params.channel_file // null)' < "${payload}")"
@@ -115,6 +116,7 @@ then
 {
   "text": ${text_interpolated},
   "username": ${username},
+  "link_names": ${link_names}
   "icon_url": ${icon_url},
   "icon_emoji": ${icon_emoji},
   "channel": ${channel},


### PR DESCRIPTION
PR to add functionality for the user to use `link_names` in slack notification. This gives the user possibility to ping user groups etc which otherwise is impossible. 