### PR TITLE
Clarify docs and tests around empty text files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ the following will be sent under these conditions:
   - `text_file` omitted, or present but file missing
     * `$TEXT_FILE_CONTENT` is replaced with "*(no notification given)*"
   - `text_file` specified and present but file empty:
-    * `$TEXT_FILE_CONTENT` is replaced with empty string.
+    * no notification is sent
 
 Optional:
 

--- a/test/combined_text_template_and_file_missing.out
+++ b/test/combined_text_template_and_file_missing.out
@@ -3,7 +3,6 @@
     "text_file": "sample-missing.txt",
     "text": ":some_emoji:<https://my-ci.my-org.com/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|Alert!>\n$TEXT_FILE_CONTENT\n",
     "username": "concourse",
-    "always_notify": "true",
     "debug": "true"
   },
   "source": {


### PR DESCRIPTION
Before #47, setting `text_file` to an empty or missing file resulted in
no notification being sent. After #47, setting `text_file` to an empty
file continued to result in no notification, but setting to an empty
file sent a notification. This patch updates docs and tests to clarify
the current expected behavior around empty and missing text files.