### PR TITLE
Feature link names

### DIFF
--- a/out
+++ b/out
@@ -23,6 +23,7 @@ text="$(jq -r '(.params.text // "${TEXT_FILE_CONTENT}")' < "${payload}")"
 username="$(jq '(.params.username // null)' < "${payload}")"
 icon_url="$(jq '(.params.icon_url // null)' < "${payload}")"
 icon_emoji="$(jq '(.params.icon_emoji // null)' < "${payload}")"
+link_names="$(jq -r '(.params.link_names // false)' < "${payload}")"
 
 channels="$(jq -r '(.params.channel // null)' < "${payload}")"
 channel_file="$(jq -r '(.params.channel_file // null)' < "${payload}")"
@@ -115,6 +116,7 @@ then
 {
   "text": ${text_interpolated},
   "username": ${username},
+  "link_names": ${link_names},
   "icon_url": ${icon_url},
   "icon_emoji": ${icon_emoji},
   "channel": ${channel},

--- a/test/all.sh
+++ b/test/all.sh
@@ -48,8 +48,6 @@ missing_text="_(no notification provided)_"
 
 username="concourse"
 
-test combined_text_template_and_file
-
 test combined_text_template_and_file | jq -e "
   .webhook_url == $(echo $webhook_url | jq -R .) and
   .body.channel == null and

--- a/test/all.sh
+++ b/test/all.sh
@@ -48,16 +48,19 @@ missing_text="_(no notification provided)_"
 
 username="concourse"
 
+test combined_text_template_and_file
+
 test combined_text_template_and_file | jq -e "
   .webhook_url == $(echo $webhook_url | jq -R .) and
   .body.channel == null and
   .body.icon_url == null and
   .body.icon_emoji == null and
+  .body.link_names == false and
   .body.username == $(echo $username | jq -R .) and
   .body.text == \"${base_text}\n${sample_text}\" and
   .body.attachments == null and
-  ( .body | keys | contains([\"channel\",\"icon_emoji\",\"icon_url\",\"username\",\"text\",\"attachments\"]) ) and
-  ( .body | keys | length ==  6 )"
+  ( .body | keys | contains([\"channel\",\"icon_emoji\",\"icon_url\",\"username\",\"link_names\",\"text\",\"attachments\"]) ) and
+  ( .body | keys | length ==  7 )"
 
 
 test combined_text_template_and_file_empty | jq -e "
@@ -65,11 +68,12 @@ test combined_text_template_and_file_empty | jq -e "
   .body.channel == null and
   .body.icon_url == null and
   .body.icon_emoji == null and
+  .body.link_names == false and
   .body.username == $(echo $username | jq -R .) and
   .body.text == \"${base_text}\n${missing_text}\n\" and
   .body.attachments == null and
-  ( .body | keys | contains([\"channel\",\"icon_emoji\",\"icon_url\",\"username\",\"text\",\"attachments\"]) ) and
-  ( .body | keys | length ==  6 )"
+  ( .body | keys | contains([\"channel\",\"icon_emoji\",\"icon_url\",\"username\",\"link_names\",\"text\",\"attachments\"]) ) and
+  ( .body | keys | length ==  7 )"
 
 
 test combined_text_template_and_file_missing | jq -e "
@@ -77,44 +81,48 @@ test combined_text_template_and_file_missing | jq -e "
   .body.channel == null and
   .body.icon_url == null and
   .body.icon_emoji == null and
+  .body.link_names == false and
   .body.username == $(echo $username | jq -R .) and
   .body.text == \"${base_text}\n${missing_text}\n\" and
   .body.attachments == null and
-  ( .body | keys | contains([\"channel\",\"icon_emoji\",\"icon_url\",\"username\",\"text\",\"attachments\"]) ) and
-  ( .body | keys | length ==  6 )"
+  ( .body | keys | contains([\"channel\",\"icon_emoji\",\"icon_url\",\"username\",\"link_names\",\"text\",\"attachments\"]) ) and
+  ( .body | keys | length ==  7 )"
 
 test text | jq -e "
   .webhook_url == $(echo $webhook_url | jq -R .) and
   .body.channel == null and
   .body.icon_url == null and
   .body.icon_emoji == null and
+  .body.link_names == false and
   .body.username == $(echo $username | jq -R .) and
   .body.text == \"Inline static \`text\`\n\" and
   .body.attachments == null and
-  ( .body | keys | contains([\"channel\",\"icon_emoji\",\"icon_url\",\"username\",\"text\",\"attachments\"]) ) and
-  ( .body | keys | length ==  6 )"
+  ( .body | keys | contains([\"channel\",\"icon_emoji\",\"icon_url\",\"username\",\"link_names\",\"text\",\"attachments\"]) ) and
+  ( .body | keys | length ==  7 )"
 
 test text_file | jq -e "
   .webhook_url == $(echo $webhook_url | jq -R .) and
   .body.channel == null and
   .body.icon_url == null and
   .body.icon_emoji == null and
+  .body.link_names == false and
   .body.username == $(echo $username | jq -R .) and
   .body.text == \"${sample_text}\" and
   .body.attachments == null and
-  ( .body | keys | contains([\"channel\",\"icon_emoji\",\"icon_url\",\"username\",\"text\",\"attachments\"]) ) and
-  ( .body | keys | length ==  6 )"
+  ( .body | keys | contains([\"channel\",\"icon_emoji\",\"icon_url\",\"username\",\"link_names\",\"text\",\"attachments\"]) ) and
+  ( .body | keys | length ==  7 )"
 
 test text_file_empty | jq -e "
   .webhook_url == $(echo $webhook_url | jq -R .) and
   .body.channel == null and
   .body.icon_url == null and
   .body.icon_emoji == null and
+  .body.link_names == false and
   .body.username == $(echo $username | jq -R .) and
   .body.text == \"${missing_text}\n\" and
   .body.attachments == null and
-  ( .body | keys | contains([\"channel\",\"icon_emoji\",\"icon_url\",\"username\",\"text\",\"attachments\"]) ) and
-  ( .body | keys | length ==  6 )"
+  ( .body | keys | contains([\"channel\",\"icon_emoji\",\"icon_url\",\"username\",\"link_names\",\"text\",\"attachments\"]) ) and
+  ( .body | keys | length ==  7 )"
 
 test text_file_empty_suppress | jq -e "
   ( . | keys | length == 1 ) and
@@ -183,10 +191,11 @@ test multiple_channels | jq -e "
   .body.channel == \"#another_channel\" and
   .body.icon_url == null and
   .body.icon_emoji == null and
+  .body.link_names == false and
   .body.username == $(echo $username | jq -R .) and
   .body.text == \"Inline static text\n\" and
-  ( .body | keys | contains([\"attachments\", \"channel\",\"icon_emoji\",\"icon_url\",\"username\",\"text\"]) ) and
-  ( .body | keys | length ==  6 ) and
+  ( .body | keys | contains([\"attachments\", \"channel\",\"icon_emoji\",\"icon_url\",\"username\",\"link_names\",\"text\"]) ) and
+  ( .body | keys | length ==  7 ) and
   .body.attachments == null"
 
 


### PR DESCRIPTION
Added functionality to be able to set `link_names` as parameter in pipeline with it defaulting to `false`. Also modified the tests so they actually pass with the new added parameter. Has been tested in a pipeline with successfully notified user group by writing @<group-name> which then mentioned the group. Was tested by using 
```
resource_types:
- name: slack-notification
  type: docker-image
  source:
    repository: quay.io/pontusarfwedson/slack-notification-resource
    tag: feature-link-names
```
in our pipeline (which points to a docker image build from this exact branch).

Difference from latest PR is that we now do not have a missing `comma` in the json in the `out` file and also the tests has been altered to include the new param.