### PR TITLE
Add disable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To setup an [Incoming Webhook](https://api.slack.com/incoming-webhooks) go to ht
 -   `insecure`: *Optional.* Connect to Slack insecurely - i.e. skip SSL validation. Defaults to false if not provided.
 - `proxy`: *Optional.* Connect to Slack using an HTTP(S) proxy. In the form: `http://my.proxy:3128`
 - `proxy_https_tunnel`: *Optional.* Set to `true` to use an HTTP proxy as an HTTPS tunnel.
+- `disable`: *Optional.* Set to `true` to skip all messaging. Convenient for temporarily disabling notifications without editing your pipelines.
 -   `ca_certs`: *Optional.* An array of objects with the following format:
 
   ```yaml

--- a/out
+++ b/out
@@ -14,6 +14,15 @@ payload=$(mktemp /tmp/resource-in.XXXXXX)
 
 cat > "${payload}" <&0
 
+timestamp="$(jq -n "{version:{timestamp:\"$(date +%s)\"}}")"
+
+disable="$(jq -r '.source.disable' < "${payload}")"
+if [[ "$disable" == "true" ]]
+then
+    echo "$timestamp" >&3
+    exit 0
+fi
+
 webhook_url="$(jq -r '.source.url' < "${payload}")"
 allow_insecure="$(jq -r '.source.insecure // "false"' < "${payload}")"
 raw_ca_certs=$(jq -r '.source.ca_certs // []' < $payload)
@@ -187,5 +196,4 @@ EOF
 
 fi
 
-timestamp="$(jq -n "{version:{timestamp:\"$(date +%s)\"}}")"
 echo "$timestamp $metadata $debug_info " | jq -s add  >&3


### PR DESCRIPTION
The purpose of this option is to be able to temporarily disable Slack notifications (for testing pipeline configurations or errors) without editing the whole pipeline to remove or comment out the `put` steps and the resource itself.

I wasn't sure how to add a test for this since it essentially skips everything.
If you think this should be implemented differently (like outputting a message or more data) please feel free to say so and I'll edit this.