### PR TITLE
Use `curl -T` to avoid argument length limit

### DIFF
--- a/out
+++ b/out
@@ -143,6 +143,7 @@ EOF
   )"
 
   compact_body="$(echo "${body}" | jq -c '.')"
+  echo "$compact_body" > /tmp/compact_body.json
 
   if [[ "$debug" == "true" ]]
   then
@@ -156,13 +157,13 @@ EOF
   elif [[ "$silent" == "true" ]]
   then
     echo "Using silent output"
-    curl -s --data-urlencode "payload=${compact_body}" ${CURL_OPTION} "${webhook_url}"
+    curl -s -T /tmp/compact_body.json ${CURL_OPTION} "${webhook_url}"
   elif [[ ${redact_hook} == "true" ]]
   then
     url_path="$(echo ${webhook_url} | sed -e "s/https\{0,1\}:\/\/[^\/]*\(\/[^?&#]*\).*/\1/")"
-    curl -v --data-urlencode "payload=${compact_body}" ${CURL_OPTION} "${webhook_url}" 2>&1 | sed -e "s#${url_path}#***WEBHOOK URL REDACTED***#g"
+    curl -v -T /tmp/compact_body.json ${CURL_OPTION} "${webhook_url}" 2>&1 | sed -e "s#${url_path}#***WEBHOOK URL REDACTED***#g"
   else
-    curl -v --data-urlencode "payload=${compact_body}" ${CURL_OPTION} "${webhook_url}" | sed -e "s#${url_path}#***WEBHOOK URL REDACTED***#g"
+    curl -v -T /tmp/compact_body.json ${CURL_OPTION} "${webhook_url}" | sed -e "s#${url_path}#***WEBHOOK URL REDACTED***#g"
   fi
 else
   text_interplated="$(echo "" | jq -R -s .)"


### PR DESCRIPTION
Signed-off-by: Conor Nosal <cnosal@pivotal.io>

If the payload is too large, curl will fail with `argument list too long: curl`. Write the payload to a temporary file and use `curl -T` to avoid this limitation.