### PR TITLE
adding fix for mattermost compatibility

### DIFF
--- a/out
+++ b/out
@@ -142,7 +142,13 @@ then
 EOF
   )"
 
-  compact_body="$(echo "${body}" | jq -c '.')"
+  # needed for mattermost compatibility as they don't accept link_names
+  if [[ "$link_names" == "true" ]]
+  then
+    compact_body="$(echo "${body}" | jq -c '.')"
+  else
+    compact_body="$(echo "${body}" | jq -c 'with_entries(select(.key != "link_names"))')"
+  fi
   echo "$compact_body" > /tmp/compact_body.json
 
   if [[ "$debug" == "true" ]]


### PR DESCRIPTION
I know this is a slack notifier but this PR would fix compatibility with mattermost which is almost fully compatible with Slack API. Except it doesn't accept `link_names` as it does this automatically. This should pretty much be a no op, I have tested and all tests pass. Referencing PR where `link_names` was added
https://github.com/cloudfoundry-community/slack-notification-resource/pull/51