### PR TITLE
Update to alpine 3.11 for curl updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.11
 
 RUN apk add --no-cache curl bash jq gettext-dev
 


### PR DESCRIPTION
curl returns a very verbose "* Expire in 1 ms for 1 (transfer 0x55df982f57a0)"
message when communicating with slack, which seems to be a bug that was fixed
in a curl update. https://curl.haxx.se/mail/lib-2019-02/0053.html