### PR TITLE
Escape values from env_file

### DIFF
--- a/out
+++ b/out
@@ -55,7 +55,7 @@ if [ -f "$env_file" ]; then
   # export key=value, when value as space but no quotes
   search_key_val='(\w+)=([^\n]+)'
   
-  source <(sed -E -n -r "s/$search_key_val/export \1=\"\2\"/ p" "$env_file")
+  source <(sed -En -e 's/(["\`$])/\\\1/g' -e "s/$search_key_val/export \1=\"\2\"/ p" "$env_file")
 fi
 
 cert_count="$(echo $raw_ca_certs | jq -r '. | length')"


### PR DESCRIPTION
This commit sanitizes the values of the `env_file`. Currently the values are source'd as they are, causing `out` to crash with certain envvar values (e.g., those containing double quotes, which is what happened to me), and even allowing arbitrary code injection. This PR should protect against all dangerous escape characters in Bash (", \, `, $).

Thanks and keep up the good work!