### PR TITLE
Release docker image for arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,18 @@
 IMAGE   ?= cfcommunity/slack-notification-resource
 VERSION ?= dev
 
-build:
-	docker build \
+install:
+	mkdir -vp ~/.docker/cli-plugins/
+	curl --silent -L "https://github.com/docker/buildx/releases/download/v0.4.2/buildx-v0.4.2.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+	chmod a+x ~/.docker/cli-plugins/docker-buildx
+	docker run --rm --privileged docker/binfmt:66f9012c56a8316f9244ffd7622d7c21c1f6f28d
+	docker buildx create --use --name mybuilder
+
+build: install
+	docker buildx build --platform linux/amd64,linux/arm64 \
 	  --build-arg BUILD_DATE="$(shell date -u --iso-8601)" \
 	  --build-arg VCS_REF="$(shell git rev-parse --short HEAD)" \
-	  --build-arg vERSION="$(VERSION)" \
-	  . -t $(IMAGE):$(VERSION)
-
-push: build
-	docker push $(IMAGE):$(VERSION)
+	  --build-arg VERSION="$(VERSION)" \
+	  -t $(IMAGE):$(VERSION) -t $(IMAGE):latest --push .
 
 release: build
-	docker tag $(IMAGE):$(VERSION) $(IMAGE):latest
-	docker push $(IMAGE):latest
-	docker push $(IMAGE):$(VERSION)


### PR DESCRIPTION
The following files have been modified:
In MAKEFILE:
1. I have used buildx to build and push the image for both platforms.
2. Added install tag to install buildx binary and created a new builder and switched to it.